### PR TITLE
Upkeep/switch to etcd bbolt fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ This repository provides the `raftboltdb` package. The package exports the
 It is meant to be used as a backend for the `raft` [package
 here](https://github.com/hashicorp/raft).
 
-This implementation uses [BoltDB](https://github.com/boltdb/bolt). BoltDB is
-a simple key/value store implemented in pure Go, and inspired by LMDB.
+This implementation uses [bbolt](https://github.com/etcd-io/bbolt), a currently
+maintained fork of the original [BoltDB](https://github.com/boltdb/bolt).
+
+BoltDB is a simple key/value store implemented in pure Go, and inspired by LMDB.

--- a/bolt_store.go
+++ b/bolt_store.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/hashicorp/raft"
-        bolt "go.etcd.io/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/bolt_store.go
+++ b/bolt_store.go
@@ -3,8 +3,8 @@ package raftboltdb
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
 	"github.com/hashicorp/raft"
+        bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/bolt_store_test.go
+++ b/bolt_store_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
-        bolt "go.etcd.io/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 func testBoltStore(t testing.TB) *BoltStore {

--- a/bolt_store_test.go
+++ b/bolt_store_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/hashicorp/raft"
+        bolt "go.etcd.io/bbolt"
 )
 
 func testBoltStore(t testing.TB) *BoltStore {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/hashicorp/raft-boltdb
+
+require (
+	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c
+	github.com/hashicorp/raft v1.0.0
+	go.etcd.io/bbolt v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
+github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
+github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c h1:BTAbnbegUIMB6xmQCwWE8yRzbA4XSpnZY5hvRJC188I=
+github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/raft v1.0.0 h1:htBVktAOtGs4Le5Z7K8SF5H2+oWsQFYVmOgH5loro7Y=
+github.com/hashicorp/raft v1.0.0/go.mod h1:DVSAWItjLjTOkVbSpWQ0j0kUADIvDaCtBxIcbNAQLkI=
+go.etcd.io/bbolt v1.3.0 h1:oY10fI923Q5pVCVt1GBTZMn8LHo5M+RCInFpeMnV4QI=
+go.etcd.io/bbolt v1.3.0/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
Looks like somebody else already had the idea, but the bbolt repo moved once again to a different organization: https://github.com/hashicorp/raft-boltdb/pull/10

Closes https://github.com/hashicorp/raft-boltdb/issues/11