### PR TITLE
Disable database migration code on unsupported platforms or if the nobolt tag is present

### DIFF
--- a/v2/bolt_migrate.go
+++ b/v2/bolt_migrate.go
@@ -1,0 +1,77 @@
+//go:build (386 || amd64 || arm || arm64 || ppc || ppc64 || ppc64le || s390x) && !nobolt
+// +build 386 amd64 arm arm64 ppc ppc64 ppc64le s390x
+// +build !nobolt
+
+package raftboltdb
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	v1 "github.com/boltdb/bolt"
+)
+
+// MigrateToV2 reads in the source file path of a BoltDB file
+// and outputs all the data migrated to a Bbolt destination file
+func MigrateToV2(source, destination string) (*BoltStore, error) {
+	_, err := os.Stat(destination)
+	if err == nil {
+		return nil, fmt.Errorf("file exists in destination %v", destination)
+	}
+
+	srcDb, err := v1.Open(source, dbFileMode, &v1.Options{
+		ReadOnly: true,
+		Timeout:  1 * time.Minute,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed opening source database: %v", err)
+	}
+
+	//Start a connection to the source
+	srctx, err := srcDb.Begin(false)
+	if err != nil {
+		return nil, fmt.Errorf("failed connecting to source database: %v", err)
+	}
+	defer srctx.Rollback()
+
+	//Create the destination
+	destDb, err := New(Options{Path: destination})
+	if err != nil {
+		return nil, fmt.Errorf("failed creating destination database: %v", err)
+	}
+	//Start a connection to the new
+	desttx, err := destDb.conn.Begin(true)
+	if err != nil {
+		destDb.Close()
+		os.Remove(destination)
+		return nil, fmt.Errorf("failed connecting to destination database: %v", err)
+	}
+
+	defer desttx.Rollback()
+
+	//Loop over both old buckets and set them in the new
+	buckets := [][]byte{dbConf, dbLogs}
+	for _, b := range buckets {
+		srcB := srctx.Bucket(b)
+		destB := desttx.Bucket(b)
+		err = srcB.ForEach(func(k, v []byte) error {
+			return destB.Put(k, v)
+		})
+		if err != nil {
+			destDb.Close()
+			os.Remove(destination)
+			return nil, fmt.Errorf("failed to copy %v bucket: %v", string(b), err)
+		}
+	}
+
+	//If the commit fails, clean up
+	if err := desttx.Commit(); err != nil {
+		destDb.Close()
+		os.Remove(destination)
+		return nil, fmt.Errorf("failed commiting data to destination: %v", err)
+	}
+
+	return destDb, nil
+
+}

--- a/v2/bolt_migrate_nobolt.go
+++ b/v2/bolt_migrate_nobolt.go
@@ -1,0 +1,10 @@
+//go:build (!386 && !amd64 && !arm && !arm64 && !ppc && !ppc64 && !ppc64le && !s390x) || nobolt
+// +build !386,!amd64,!arm,!arm64,!ppc,!ppc64,!ppc64le,!s390x nobolt
+
+package raftboltdb
+
+// MigrateToV2 reads in the source file path of a BoltDB file
+// and outputs all the data migrated to a Bbolt destination file
+func MigrateToV2(source, destination string) (*BoltStore, error) {
+	return nil, ErrNotImplemented
+}

--- a/v2/bolt_migrate_test.go
+++ b/v2/bolt_migrate_test.go
@@ -1,0 +1,71 @@
+//go:build (386 || amd64 || arm || arm64 || ppc || ppc64 || ppc64le || s390x) && !nobolt
+// +build 386 amd64 arm arm64 ppc ppc64 ppc64le s390x
+// +build !nobolt
+
+package raftboltdb
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	v1 "github.com/hashicorp/raft-boltdb"
+)
+
+func TestBoltStore_MigrateToV2(t *testing.T) {
+
+	dir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	srcFile := filepath.Join(dir, "/sourcepath")
+	destFile := filepath.Join(dir, "/destpath")
+
+	// Successfully creates and returns a store
+	srcDb, err := v1.NewBoltStore(srcFile)
+	if err != nil {
+		t.Fatalf("failed creating source database: %s", err)
+	}
+	defer srcDb.Close()
+
+	// Set a mock raft log
+	logs := []*raft.Log{
+		testRaftLog(1, "log1"),
+		testRaftLog(2, "log2"),
+		testRaftLog(3, "log3"),
+	}
+
+	//Store logs source
+	if err := srcDb.StoreLogs(logs); err != nil {
+		t.Fatalf("failed storing logs in source database: %s", err)
+	}
+	srcResult := new(raft.Log)
+	if err := srcDb.GetLog(2, srcResult); err != nil {
+		t.Fatalf("failed getting log from source database: %s", err)
+	}
+
+	if err := srcDb.Close(); err != nil {
+		t.Fatalf("failed closing source database: %s", err)
+	}
+
+	destDb, err := MigrateToV2(srcFile, destFile)
+	if err != nil {
+		t.Fatalf("did not migrate successfully, err %v", err)
+	}
+	defer destDb.Close()
+
+	destResult := new(raft.Log)
+	if err := destDb.GetLog(2, destResult); err != nil {
+		t.Fatalf("failed getting log from destination database: %s", err)
+	}
+
+	if !reflect.DeepEqual(srcResult, destResult) {
+		t.Errorf("BoltDB log did not equal Bbolt log, Boltdb %v, Bbolt: %v", srcResult, destResult)
+	}
+
+}

--- a/v2/bolt_store.go
+++ b/v2/bolt_store.go
@@ -2,12 +2,9 @@ package raftboltdb
 
 import (
 	"errors"
-	"fmt"
-	"os"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	v1 "github.com/boltdb/bolt"
 	"github.com/hashicorp/raft"
 	"go.etcd.io/bbolt"
 )
@@ -25,6 +22,8 @@ var (
 
 	// An error indicating a given key does not exist
 	ErrKeyNotFound = errors.New("not found")
+	// An error indicating a feature isn't implemented on the current platform
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 // BoltStore provides access to Bbolt for Raft to store and retrieve
@@ -296,68 +295,4 @@ func (b *BoltStore) GetUint64(key []byte) (uint64, error) {
 // database file to sync against the disk.
 func (b *BoltStore) Sync() error {
 	return b.conn.Sync()
-}
-
-// MigrateToV2 reads in the source file path of a BoltDB file
-// and outputs all the data migrated to a Bbolt destination file
-func MigrateToV2(source, destination string) (*BoltStore, error) {
-	_, err := os.Stat(destination)
-	if err == nil {
-		return nil, fmt.Errorf("file exists in destination %v", destination)
-	}
-
-	srcDb, err := v1.Open(source, dbFileMode, &v1.Options{
-		ReadOnly: true,
-		Timeout:  1 * time.Minute,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed opening source database: %v", err)
-	}
-
-	//Start a connection to the source
-	srctx, err := srcDb.Begin(false)
-	if err != nil {
-		return nil, fmt.Errorf("failed connecting to source database: %v", err)
-	}
-	defer srctx.Rollback()
-
-	//Create the destination
-	destDb, err := New(Options{Path: destination})
-	if err != nil {
-		return nil, fmt.Errorf("failed creating destination database: %v", err)
-	}
-	//Start a connection to the new
-	desttx, err := destDb.conn.Begin(true)
-	if err != nil {
-		destDb.Close()
-		os.Remove(destination)
-		return nil, fmt.Errorf("failed connecting to destination database: %v", err)
-	}
-
-	defer desttx.Rollback()
-
-	//Loop over both old buckets and set them in the new
-	buckets := [][]byte{dbConf, dbLogs}
-	for _, b := range buckets {
-		srcB := srctx.Bucket(b)
-		destB := desttx.Bucket(b)
-		err = srcB.ForEach(func(k, v []byte) error {
-			return destB.Put(k, v)
-		})
-		if err != nil {
-			destDb.Close()
-			os.Remove(destination)
-			return nil, fmt.Errorf("failed to copy %v bucket: %v", string(b), err)
-		}
-	}
-
-	//If the commit fails, clean up
-	if err := desttx.Commit(); err != nil {
-		destDb.Close()
-		os.Remove(destination)
-		return nil, fmt.Errorf("failed commiting data to destination: %v", err)
-	}
-
-	return destDb, nil
-
 }

--- a/v2/bolt_store_test.go
+++ b/v2/bolt_store_test.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/raft"
-	v1 "github.com/hashicorp/raft-boltdb"
 	"go.etcd.io/bbolt"
 )
 
@@ -415,59 +413,4 @@ func TestBoltStore_SetUint64_GetUint64(t *testing.T) {
 	if val != v {
 		t.Fatalf("bad: %v", val)
 	}
-}
-
-func TestBoltStore_MigrateToV2(t *testing.T) {
-
-	dir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
-
-	srcFile := filepath.Join(dir, "/sourcepath")
-	destFile := filepath.Join(dir, "/destpath")
-
-	// Successfully creates and returns a store
-	srcDb, err := v1.NewBoltStore(srcFile)
-	if err != nil {
-		t.Fatalf("failed creating source database: %s", err)
-	}
-	defer srcDb.Close()
-
-	// Set a mock raft log
-	logs := []*raft.Log{
-		testRaftLog(1, "log1"),
-		testRaftLog(2, "log2"),
-		testRaftLog(3, "log3"),
-	}
-
-	//Store logs source
-	if err := srcDb.StoreLogs(logs); err != nil {
-		t.Fatalf("failed storing logs in source database: %s", err)
-	}
-	srcResult := new(raft.Log)
-	if err := srcDb.GetLog(2, srcResult); err != nil {
-		t.Fatalf("failed getting log from source database: %s", err)
-	}
-
-	if err := srcDb.Close(); err != nil {
-		t.Fatalf("failed closing source database: %s", err)
-	}
-
-	destDb, err := MigrateToV2(srcFile, destFile)
-	if err != nil {
-		t.Fatalf("did not migrate successfully, err %v", err)
-	}
-	defer destDb.Close()
-
-	destResult := new(raft.Log)
-	if err := destDb.GetLog(2, destResult); err != nil {
-		t.Fatalf("failed getting log from destination database: %s", err)
-	}
-
-	if !reflect.DeepEqual(srcResult, destResult) {
-		t.Errorf("BoltDB log did not equal Bbolt log, Boltdb %v, Bbolt: %v", srcResult, destResult)
-	}
-
 }


### PR DESCRIPTION
Currently, `raft-boltdb` does not compile for unsupported architectures such as RISC-V because of its dependency on the unmaintained `github.com/boltdb/bolt` library. It appears the only reason that dependency exists is to be able to migrate v1 databases to v2, but it is not needed for this package to work.

This PR moves the migration code and its associated unit tests to separate files and uses build tags to only build those files if the platform is supported by bolt and the `nobolt` tag is not set.

Here are the results of running tests on this PR:

```
$ go test -v
=== RUN   TestBoltStore_MigrateToV2
--- PASS: TestBoltStore_MigrateToV2 (0.00s)
=== RUN   TestBoltStore_Implements
--- PASS: TestBoltStore_Implements (0.00s)
=== RUN   TestBoltOptionsTimeout
--- PASS: TestBoltOptionsTimeout (0.05s)
=== RUN   TestBoltOptionsReadOnly
--- PASS: TestBoltOptionsReadOnly (0.00s)
=== RUN   TestNewBoltStore
--- PASS: TestNewBoltStore (0.00s)
=== RUN   TestBoltStore_FirstIndex
--- PASS: TestBoltStore_FirstIndex (0.00s)
=== RUN   TestBoltStore_LastIndex
--- PASS: TestBoltStore_LastIndex (0.00s)
=== RUN   TestBoltStore_GetLog
--- PASS: TestBoltStore_GetLog (0.00s)
=== RUN   TestBoltStore_SetLog
--- PASS: TestBoltStore_SetLog (0.00s)
=== RUN   TestBoltStore_SetLogs
--- PASS: TestBoltStore_SetLogs (0.00s)
=== RUN   TestBoltStore_DeleteRange
--- PASS: TestBoltStore_DeleteRange (0.00s)
=== RUN   TestBoltStore_Set_Get
--- PASS: TestBoltStore_Set_Get (0.00s)
=== RUN   TestBoltStore_SetUint64_GetUint64
--- PASS: TestBoltStore_SetUint64_GetUint64 (0.00s)
PASS
ok  	github.com/hashicorp/raft-boltdb/v2	0.056s
```

And on `riscv64`:
```
GOARCH=riscv64 go test -v
=== RUN   TestBoltStore_Implements
--- PASS: TestBoltStore_Implements (0.00s)
=== RUN   TestBoltOptionsTimeout
--- PASS: TestBoltOptionsTimeout (0.06s)
=== RUN   TestBoltOptionsReadOnly
--- PASS: TestBoltOptionsReadOnly (0.02s)
=== RUN   TestNewBoltStore
--- PASS: TestNewBoltStore (0.00s)
=== RUN   TestBoltStore_FirstIndex
--- PASS: TestBoltStore_FirstIndex (0.00s)
=== RUN   TestBoltStore_LastIndex
--- PASS: TestBoltStore_LastIndex (0.00s)
=== RUN   TestBoltStore_GetLog
--- PASS: TestBoltStore_GetLog (0.00s)
=== RUN   TestBoltStore_SetLog
--- PASS: TestBoltStore_SetLog (0.00s)
=== RUN   TestBoltStore_SetLogs
--- PASS: TestBoltStore_SetLogs (0.00s)
=== RUN   TestBoltStore_DeleteRange
--- PASS: TestBoltStore_DeleteRange (0.00s)
=== RUN   TestBoltStore_Set_Get
--- PASS: TestBoltStore_Set_Get (0.00s)
=== RUN   TestBoltStore_SetUint64_GetUint64
--- PASS: TestBoltStore_SetUint64_GetUint64 (0.00s)
PASS
ok  	github.com/hashicorp/raft-boltdb/v2	0.154s
```

Fixes #27