### PR TITLE
fix: vulnerability fix use commit hash instead of version

### DIFF
--- a/.github/workflows/two-step-pr-approval.yml
+++ b/.github/workflows/two-step-pr-approval.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       
       - name: Two stage PR review
         uses: hashicorp/two-stage-pr-approval@v0.1.0


### PR DESCRIPTION
use commit hash to reference external actions instead of tags.